### PR TITLE
feat: add branded navigation and admin panel

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>Altkom Auctions</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
+        "@types/node": "^24.2.1",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/tsconfig": "^0.7.0",
         "typescript": "~5.8.3",
@@ -814,6 +815,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.1",
@@ -1661,6 +1672,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@types/node": "^24.2.1",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.7.0",
     "typescript": "~5.8.3",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,23 +1,10 @@
 <script setup lang="ts">
-import { computed } from "vue";
-
-const user = computed(() => {
-  const raw = localStorage.getItem("user");
-  return raw ? JSON.parse(raw) : null;
-});
+import NavBar from "@/components/NavBar.vue";
 </script>
 
 <template>
-  <header style="padding:12px;border-bottom:1px solid #eee;display:flex;gap:12px">
-    <router-link to="/" style="font-weight:700;text-decoration:none;color:#111">Auctions</router-link>
-    <nav style="margin-left:auto;display:flex;gap:10px">
-      <router-link to="/">Lista</router-link>
-      <router-link v-if="user?.role==='ADMIN'" to="/create">Dodaj aukcję</router-link>
-      <router-link v-if="!user" to="/login">Zaloguj</router-link>
-      <span v-else>Witaj, {{ user.name }}</span>
-    </nav>
-  </header>
-  <main style="max-width:960px;margin:20px auto;padding:0 16px">
+  <NavBar />
+  <main class="container">
     <router-view />
   </main>
 </template>

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+const user = computed(() => {
+  const raw = localStorage.getItem('user');
+  return raw ? JSON.parse(raw) : null;
+});
+
+function logout() {
+  localStorage.removeItem('user');
+  router.push('/');
+  window.location.reload();
+}
+</script>
+
+<template>
+  <header class="topbar">
+    <router-link to="/" class="brand">Altkom Software &amp; Consulting</router-link>
+    <nav class="links">
+      <router-link to="/">Lista</router-link>
+      <router-link v-if="user?.role==='ADMIN'" to="/create">Dodaj aukcję</router-link>
+      <router-link v-if="user?.role==='ADMIN'" to="/admin">Panel admina</router-link>
+      <router-link v-if="!user" to="/login">Zaloguj</router-link>
+      <span v-else class="welcome">Witaj, {{ user.name }}</span>
+      <button v-if="user" class="btn small" @click="logout">Wyloguj</button>
+    </nav>
+  </header>
+</template>

--- a/frontend/src/pages/AdminDashboard.vue
+++ b/frontend/src/pages/AdminDashboard.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { api } from '@/api';
+
+type Auction = {
+  id: string;
+  title: string;
+};
+
+const auctions = ref<Auction[]>([]);
+const error = ref<string | null>(null);
+
+onMounted(async () => {
+  try {
+    const { data } = await api.get('/auctions');
+    auctions.value = data;
+  } catch (e: any) {
+    error.value = e?.message ?? 'Błąd';
+  }
+});
+</script>
+
+<template>
+  <section>
+    <h1>Panel administracyjny</h1>
+    <p v-if="error" style="color:red">{{ error }}</p>
+    <ul>
+      <li v-for="a in auctions" :key="a.id">{{ a.title }}</li>
+    </ul>
+  </section>
+</template>
+

--- a/frontend/src/pages/CreateAuction.vue
+++ b/frontend/src/pages/CreateAuction.vue
@@ -35,15 +35,15 @@ async function submit() {
 
 <template>
   <h1>Nowa aukcja</h1>
-  <form @submit.prevent="submit" style="display:grid;gap:10px;max-width:560px">
+  <form @submit.prevent="submit" class="form">
     <input v-model="title" placeholder="Tytuł" required />
     <textarea v-model="description" placeholder="Opis" rows="4" required />
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+    <div class="form-row">
       <input v-model="basePricePLN" type="number" step="0.01" placeholder="Cena wywoławcza (PLN)" required />
       <input v-model="minIncrementPLN" type="number" step="0.01" placeholder="Min. przebitka (PLN)" required />
       <input v-model="reservePricePLN" type="number" step="0.01" placeholder="Cena minimalna (opc.)" />
     </div>
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+    <div class="form-row">
       <label>Start: <input v-model="startsAt" type="datetime-local" required /></label>
       <label>Koniec: <input v-model="endsAt" type="datetime-local" required /></label>
     </div>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -42,23 +42,23 @@ function fmtDate(s: string) {
 
   <div
     v-if="!loading && auctions.length"
-    style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px"
+    class="auction-grid"
   >
     <router-link
       v-for="a in auctions"
       :key="a.id"
       :to="`/auction/${a.id}`"
-      style="text-decoration:none;color:inherit"
+      class="auction-link"
     >
-      <article style="border:1px solid #eee;border-radius:8px;padding:12px;transition:.15s box-shadow">
+      <article class="auction-card">
         <img
           v-if="a.images?.[0]"
           :src="`${backend}${a.images[0].url}`"
           alt=""
-          style="width:100%;height:160px;object-fit:cover;border-radius:6px"
+          class="auction-image"
         />
-        <h3 style="margin:8px 0 4px">{{ a.title }}</h3>
-        <p style="color:#555;font-size:14px;min-height:40px">{{ a.description }}</p>
+        <h3>{{ a.title }}</h3>
+        <p>{{ a.description }}</p>
         <small>Kończy się: {{ fmtDate(a.endsAt) }}</small>
       </article>
     </router-link>

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -22,7 +22,7 @@ async function submit() {
 
 <template>
   <h1>Logowanie</h1>
-  <form @submit.prevent="submit" style="display:flex;flex-direction:column;gap:10px;max-width:360px">
+  <form @submit.prevent="submit" class="login-form">
     <input v-model="email" type="email" placeholder="email" required />
     <input v-model="password" type="password" placeholder="hasło" required />
     <button :disabled="loading" type="submit">Zaloguj</button>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import Home from "@/pages/Home.vue";
 import Login from "@/pages/Login.vue";
 import CreateAuction from "@/pages/CreateAuction.vue";
 import AuctionDetail from "@/pages/AuctionDetail.vue";
+import AdminDashboard from "@/pages/AdminDashboard.vue";
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -10,6 +11,7 @@ export const router = createRouter({
     { path: "/", component: Home },
     { path: "/login", component: Login },
     { path: "/create", component: CreateAuction },
+    { path: "/admin", component: AdminDashboard },
     { path: "/auction/:id", component: AuctionDetail }, // NEW
   ],
 });

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2,11 +2,8 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #213547;
+  background-color: #ffffff;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,65 +12,123 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: #004080;
+  text-decoration: none;
 }
 a:hover {
-  color: #535bf2;
+  color: #0066cc;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
+  border-radius: 4px;
+  border: 1px solid #004080;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #004080;
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s, border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: #0059b3;
+  border-color: #0059b3;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-.card {
-  padding: 2em;
+.topbar {
+  display: flex;
+  align-items: center;
+  padding: 12px 24px;
+  border-bottom: 1px solid #e5e5e5;
+  background: #fff;
+}
+.brand {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #004080;
+}
+.links {
+  margin-left: auto;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.links a {
+  color: #333;
+}
+.links a.router-link-active {
+  font-weight: 600;
+}
+.welcome {
+  color: #555;
+}
+.btn.small {
+  font-size: 0.8rem;
+  padding: 0.3em 0.6em;
 }
 
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.container {
+  max-width: 960px;
+  margin: 20px auto;
+  padding: 0 16px;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.auction-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+.auction-link {
+  text-decoration: none;
+  color: inherit;
+}
+.auction-card {
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 12px;
+  transition: 0.15s box-shadow;
+}
+.auction-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+.auction-image {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 6px;
+}
+.auction-card h3 {
+  margin: 8px 0 4px;
+}
+.auction-card p {
+  color: #555;
+  font-size: 14px;
+  min-height: 40px;
+}
+
+.form {
+  display: grid;
+  gap: 10px;
+  max-width: 560px;
+}
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 360px;
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -2,6 +2,8 @@
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] },
 
     /* Linting */
     "strict": true,

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -5,6 +5,7 @@
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["node"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -19,7 +20,10 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
-import path from "path";
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
   plugins: [vue()],
-  resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
+  resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
 });


### PR DESCRIPTION
## Summary
- add Altkom-branded navigation bar with login and admin links
- introduce simple admin dashboard page and responsive auction grid
- refresh global styles and configure TypeScript paths

## Testing
- `cd frontend && npm run build`
- `cd backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c34bbd44832583a68955fad0654c