### PR TITLE
feat: improve navigation and login with SSO/LDAP options

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -18,13 +18,15 @@ function logout() {
 <template>
   <header class="topbar">
     <router-link to="/" class="brand">Altkom Software &amp; Consulting</router-link>
-    <nav class="links">
+    <nav class="nav-links">
       <router-link to="/">Lista</router-link>
       <router-link v-if="user?.role==='ADMIN'" to="/create">Dodaj aukcję</router-link>
       <router-link v-if="user?.role==='ADMIN'" to="/admin">Panel admina</router-link>
+    </nav>
+    <div class="user-links">
       <router-link v-if="!user" to="/login">Zaloguj</router-link>
       <span v-else class="welcome">Witaj, {{ user.name }}</span>
       <button v-if="user" class="btn small" @click="logout">Wyloguj</button>
-    </nav>
+    </div>
   </header>
 </template>

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -18,14 +18,44 @@ async function submit() {
     error.value = e?.response?.data?.message ?? "Błąd logowania";
   } finally { loading.value = false; }
 }
+
+async function loginSSO() {
+  loading.value = true; error.value = null;
+  try {
+    const { data } = await api.post("/auth/sso");
+    localStorage.setItem("user", JSON.stringify(data));
+    router.push("/");
+  } catch (e:any) {
+    error.value = e?.response?.data?.message ?? "Błąd logowania SSO";
+  } finally { loading.value = false; }
+}
+
+async function loginLDAP() {
+  loading.value = true; error.value = null;
+  try {
+    const { data } = await api.post("/auth/ldap", { username: email.value, password: password.value });
+    localStorage.setItem("user", JSON.stringify(data));
+    router.push("/");
+  } catch (e:any) {
+    error.value = e?.response?.data?.message ?? "Błąd logowania LDAP";
+  } finally { loading.value = false; }
+}
 </script>
 
 <template>
-  <h1>Logowanie</h1>
-  <form @submit.prevent="submit" class="login-form">
-    <input v-model="email" type="email" placeholder="email" required />
-    <input v-model="password" type="password" placeholder="hasło" required />
-    <button :disabled="loading" type="submit">Zaloguj</button>
-    <p v-if="error" style="color:red">{{ error }}</p>
-  </form>
+  <div class="login-container">
+    <div class="login-card">
+      <h1>Logowanie</h1>
+      <form @submit.prevent="submit" class="login-form">
+        <input v-model="email" type="email" placeholder="email" required />
+        <input v-model="password" type="password" placeholder="hasło" required />
+        <button :disabled="loading" type="submit">Zaloguj</button>
+      </form>
+      <div class="alt-logins">
+        <button type="button" @click="loginSSO">Zaloguj przez SSO</button>
+        <button type="button" @click="loginLDAP">Zaloguj przez LDAP</button>
+      </div>
+      <p v-if="error" class="error">{{ error }}</p>
+    </div>
+  </div>
 </template>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3,7 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
   color: #213547;
-  background-color: #ffffff;
+  background-color: #f5f7fa;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -45,28 +45,35 @@ button:focus-visible {
 }
 
 .topbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   align-items: center;
   padding: 12px 24px;
   border-bottom: 1px solid #e5e5e5;
-  background: #fff;
+  background: #f0f4f8;
 }
 .brand {
   font-weight: 700;
   font-size: 1.1rem;
   color: #004080;
 }
-.links {
-  margin-left: auto;
+.nav-links {
+  justify-self: center;
   display: flex;
   gap: 12px;
   align-items: center;
 }
-.links a {
+.nav-links a {
   color: #333;
 }
-.links a.router-link-active {
+.nav-links a.router-link-active {
   font-weight: 600;
+}
+.user-links {
+  justify-self: end;
+  display: flex;
+  gap: 12px;
+  align-items: center;
 }
 .welcome {
   color: #555;
@@ -131,4 +138,44 @@ button:focus-visible {
   flex-direction: column;
   gap: 10px;
   max-width: 360px;
+}
+
+.login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 80vh;
+}
+
+.login-card {
+  background: #fff;
+  padding: 32px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.alt-logins {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.alt-logins button {
+  background: #eee;
+  color: #333;
+  border: 1px solid #ccc;
+}
+
+.alt-logins button:hover {
+  background: #e0e0e0;
+  border-color: #bbb;
+}
+
+.error {
+  color: red;
+  margin-top: 10px;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- center main navigation and move user controls to dedicated right-side section
- refresh login page with card layout and SSO/LDAP login options
- add backend endpoints for simplified SSO and LDAP authentication

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run build` (frontend)
- `npm test` (backend) *(fails: Missing script "test")*
- `npm run build` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_6897c6e9106083259a7985c92df26853