### PR TITLE
Improve admin panel navigation and landing page

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -27,13 +27,12 @@ function logout() {
       <router-link to="/auctions">Aukcje</router-link>
       <router-link to="/info">Informacje</router-link>
       <router-link to="/contact">Kontakt</router-link>
-      <router-link v-if="user?.role==='ADMIN'" to="/create">Dodaj aukcję</router-link>
     </nav>
     <div class="user-links">
       <router-link v-if="user?.role==='ADMIN'" to="/admin" class="admin-link">Panel admina</router-link>
       <router-link v-if="!user" to="/login">Zaloguj</router-link>
       <span v-else class="welcome">Witaj, {{ user.name }}</span>
-      <button v-if="user" class="btn small" @click="logout">Wyloguj</button>
+      <button v-if="user" class="btn small logout-btn" @click="logout">Wyloguj</button>
     </div>
   </header>
 </template>

--- a/frontend/src/pages/AdminDashboard.vue
+++ b/frontend/src/pages/AdminDashboard.vue
@@ -78,7 +78,9 @@ async function submitRelist() {
     <div class="admin-layout">
       <aside class="admin-nav">
         <ul>
-          <li class="active"><router-link to="/admin">Aukcje</router-link></li>
+          <li><router-link to="/admin/create">Dodaj Aukcję</router-link></li>
+          <li><router-link to="/admin">Aukcje</router-link></li>
+          <li><router-link to="/admin/settings">Ustawienia</router-link></li>
         </ul>
       </aside>
       <main class="admin-content">

--- a/frontend/src/pages/AdminSettings.vue
+++ b/frontend/src/pages/AdminSettings.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const maxActiveAuctions = ref('');
+const maxWonAuctions = ref('');
+</script>
+
+<template>
+  <section class="admin-dashboard">
+    <h1>Panel administracyjny</h1>
+    <div class="admin-layout">
+      <aside class="admin-nav">
+        <ul>
+          <li><router-link to="/admin/create">Dodaj Aukcję</router-link></li>
+          <li><router-link to="/admin">Aukcje</router-link></li>
+          <li><router-link to="/admin/settings">Ustawienia</router-link></li>
+        </ul>
+      </aside>
+      <main class="admin-content">
+        <h2>Ustawienia</h2>
+        <form class="form">
+          <label>Maks. aukcji na użytkownika:
+            <input v-model="maxActiveAuctions" type="number" />
+          </label>
+          <label>Maks. wygranych aukcji:
+            <input v-model="maxWonAuctions" type="number" />
+          </label>
+        </form>
+      </main>
+    </div>
+  </section>
+</template>

--- a/frontend/src/pages/CreateAuction.vue
+++ b/frontend/src/pages/CreateAuction.vue
@@ -8,7 +8,7 @@ const title = ref(""); const description = ref("");
 const basePricePLN = ref(""); const minIncrementPLN = ref("");
 const reservePricePLN = ref(""); const startsAt = ref(""); const endsAt = ref("");
 const mainImage = ref<File|null>(null);
-const extraImages = ref<FileList|null>(null);
+const extraImages = ref<File[]>([]);
 const mainPreview = ref<string>('');
 const extraPreviews = ref<string[]>([]);
 const ok = ref<string|null>(null); const error = ref<string|null>(null); const loading = ref(false);
@@ -27,7 +27,7 @@ async function submit() {
     fd.append("startsAt", toISO(startsAt.value));
     fd.append("endsAt", toISO(endsAt.value));
     if (mainImage.value) fd.append("images", mainImage.value);
-    if (extraImages.value) Array.from(extraImages.value).forEach(f => fd.append("images", f));
+    extraImages.value.forEach(f => fd.append("images", f));
 
     const { data } = await api.post("/auctions", fd);
     ok.value = `Utworzono: ${data.title}`; setTimeout(() => router.push("/"), 700);
@@ -43,17 +43,29 @@ function onMain(e: Event) {
 }
 
 function onExtras(e: Event) {
-  const files = (e.target as HTMLInputElement).files;
-  extraImages.value = files;
-  extraPreviews.value = files ? Array.from(files).map(f => URL.createObjectURL(f)) : [];
+  const files = Array.from((e.target as HTMLInputElement).files || []);
+  extraImages.value.push(...files);
+  extraPreviews.value.push(...files.map(f => URL.createObjectURL(f)));
+  (e.target as HTMLInputElement).value = '';
 }
 </script>
 
 <template>
-  <div class="create-auction-wrapper">
-    <div class="create-auction-card">
-      <h1>Nowa aukcja</h1>
-      <form @submit.prevent="submit" class="form">
+  <section class="admin-dashboard">
+    <h1>Panel administracyjny</h1>
+    <div class="admin-layout">
+      <aside class="admin-nav">
+        <ul>
+          <li><router-link to="/admin/create">Dodaj Aukcję</router-link></li>
+          <li><router-link to="/admin">Aukcje</router-link></li>
+          <li><router-link to="/admin/settings">Ustawienia</router-link></li>
+        </ul>
+      </aside>
+      <main class="admin-content">
+        <div class="create-auction-wrapper">
+          <div class="create-auction-card">
+            <h2>Nowa aukcja</h2>
+            <form @submit.prevent="submit" class="form">
         <input v-model="title" placeholder="Tytuł" required />
         <textarea v-model="description" placeholder="Opis" rows="4" required />
         <div class="form-row">
@@ -76,7 +88,10 @@ function onExtras(e: Event) {
         <button :disabled="loading" type="submit">Utwórz aukcję</button>
         <p v-if="ok" style="color:green">{{ ok }}</p>
         <p v-if="error" style="color:red">{{ error }}</p>
-      </form>
+            </form>
+          </div>
+        </div>
+      </main>
     </div>
-  </div>
+  </section>
 </template>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -2,26 +2,64 @@
 </script>
 
 <template>
-  <section class="home-section top">
-    <h1>Witamy w Altkom Software</h1>
-    <p>Platforma aukcyjna z nowoczesnym, szarym motywem.</p>
-  </section>
-  <section class="home-section middle">
-    <h2>Dlaczego my?</h2>
-    <p>Bezpieczne licytacje, przejrzysty panel administracyjny i szybkie płatności.</p>
-  </section>
-  <section class="home-section bottom">
-    <h2>Dołącz do nas</h2>
-    <p>Załóż konto i wystaw swoją pierwszą aukcję już dziś.</p>
+  <section class="home-hero">
+    <h1 class="typewriter">
+      Witamy na Aukcji Sprzętu
+      <span class="brand inline-brand">
+        <span class="logo-alt">alt</span>
+        <span class="logo-box"><span class="logo-k">k</span></span>
+        <span class="logo-om">om software</span>
+      </span>
+    </h1>
+    <p class="hero-subtitle">
+      Dołącz do naszych licytacji firmowego sprzętu komputerowego – głównie laptopów używanych w różnym stanie technicznym. Każdy przedmiot ma indywidualny opis, abyś mógł dokładnie poznać jego specyfikację i stan przed licytacją. Licytuj w czasie rzeczywistym i zdobądź sprzęt w korzystnej cenie. Sprawdź aktualne aukcje i złóż swoją ofertę już teraz!
+    </p>
+    <router-link to="/auctions" class="cta-button">Zobacz Aktualne Aukcje</router-link>
   </section>
 </template>
 
 <style scoped>
-.home-section {
-  padding: 40px 20px;
+.home-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  padding: 80px 20px;
 }
-.top { background: #f0f0f0; }
-.middle { background: #e0e0e0; }
-.bottom { background: #d0d0d0; }
+
+.inline-brand {
+  margin-left: 8px;
+}
+
+.typewriter {
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 0.15em solid #ff4f64;
+  animation: typing 6s steps(60, end);
+}
+
+@keyframes typing {
+  from { width: 0 }
+  to { width: 100% }
+}
+
+.hero-subtitle {
+  max-width: 800px;
+  margin-top: 20px;
+}
+
+.cta-button {
+  margin-top: 30px;
+  background: #0059b3;
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 25px;
+  transition: background-color 0.3s;
+  display: inline-block;
+}
+
+.cta-button:hover {
+  background: #0066cc;
+}
 </style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,9 +4,10 @@ import Auctions from "@/pages/Auctions.vue";
 import Info from "@/pages/Info.vue";
 import Contact from "@/pages/Contact.vue";
 import Login from "@/pages/Login.vue";
-import CreateAuction from "@/pages/CreateAuction.vue";
 import AuctionDetail from "@/pages/AuctionDetail.vue";
 import AdminDashboard from "@/pages/AdminDashboard.vue";
+import CreateAuction from "@/pages/CreateAuction.vue";
+import AdminSettings from "@/pages/AdminSettings.vue";
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -16,7 +17,8 @@ export const router = createRouter({
     { path: "/info", component: Info },
     { path: "/contact", component: Contact },
     { path: "/login", component: Login },
-    { path: "/create", component: CreateAuction },
+    { path: "/admin/create", component: CreateAuction },
+    { path: "/admin/settings", component: AdminSettings },
     { path: "/admin", component: AdminDashboard },
     { path: "/auction/:id", component: AuctionDetail },
   ],

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -126,6 +126,16 @@ button:focus-visible {
   padding: 0.3em 0.6em;
 }
 
+.logout-btn {
+  background: #cc0000;
+  border-color: #cc0000;
+}
+
+.logout-btn:hover {
+  background: #ff3333;
+  border-color: #ff3333;
+}
+
 .container {
   max-width: 960px;
   margin: 20px auto;
@@ -284,20 +294,19 @@ button:focus-visible {
 
 .admin-nav li {
   margin-bottom: 10px;
+}
+
+.admin-nav a {
+  display: block;
   padding: 8px;
   border-radius: 4px;
-  cursor: pointer;
-}
-
-.admin-nav li.active {
-  background: #0059b3;
-  color: #fff;
-}
-
-.admin-nav li a {
   color: inherit;
   text-decoration: none;
-  display: block;
+}
+
+.admin-nav a.router-link-active {
+  background: #0059b3;
+  color: #fff;
 }
 
 .auction-overview {


### PR DESCRIPTION
## Summary
- Add sidebar navigation with Create, Auctions, and Settings pages in the admin panel
- Allow adding multiple additional images when creating auctions
- Introduce placeholder settings for max participation and wins
- Red logout button and new hero section with typewriter effect and CTA

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897e2bf3c8883258647ee9b1ad85cf3