### PR TITLE
Improve admin panel navigation and landing page

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -18,22 +18,20 @@ function logout() {
 <template>
   <header class="topbar">
     <router-link to="/" class="brand" aria-label="Altkom Software">
-      <span class="logo-alt">alt</span>
-      <span class="logo-box"><span class="logo-k">k</span></span>
-      <span class="logo-om">om software</span>
+      <span class="logo-alt">alt</span><span class="logo-kom">kom</span>
+      <span class="logo-om">software</span>
     </router-link>
     <nav class="nav-links">
       <router-link to="/">Start</router-link>
       <router-link to="/auctions">Aukcje</router-link>
       <router-link to="/info">Informacje</router-link>
       <router-link to="/contact">Kontakt</router-link>
-      <router-link v-if="user?.role==='ADMIN'" to="/create">Dodaj aukcję</router-link>
     </nav>
     <div class="user-links">
       <router-link v-if="user?.role==='ADMIN'" to="/admin" class="admin-link">Panel admina</router-link>
       <router-link v-if="!user" to="/login">Zaloguj</router-link>
       <span v-else class="welcome">Witaj, {{ user.name }}</span>
-      <button v-if="user" class="btn small" @click="logout">Wyloguj</button>
+      <button v-if="user" class="btn small logout-btn" @click="logout">Wyloguj</button>
     </div>
   </header>
 </template>

--- a/frontend/src/pages/AdminAuctions.vue
+++ b/frontend/src/pages/AdminAuctions.vue
@@ -78,7 +78,9 @@ async function submitRelist() {
     <div class="admin-layout">
       <aside class="admin-nav">
         <ul>
-          <li class="active"><router-link to="/admin">Aukcje</router-link></li>
+          <li><router-link to="/admin/create">Dodaj Aukcję</router-link></li>
+          <li><router-link to="/admin/auctions">Aukcje</router-link></li>
+          <li><router-link to="/admin/settings">Ustawienia</router-link></li>
         </ul>
       </aside>
       <main class="admin-content">
@@ -88,12 +90,21 @@ async function submitRelist() {
             <h2>Aktywne</h2>
             <table>
               <thead>
-                <tr><th>Tytuł</th><th>Koniec</th></tr>
+                <tr>
+                  <th>Tytuł</th>
+                  <th>Wygrywający</th>
+                  <th>Zakończenie</th>
+                  <th>Kwota startowa</th>
+                  <th>Kwota obecna</th>
+                </tr>
               </thead>
               <tbody>
                 <tr v-for="a in overview.active" :key="a.id">
                   <td>{{ a.title }}</td>
+                  <td>{{ a.winnerBid?.user.name || '—' }}</td>
                   <td>{{ fmtDate(a.endsAt) }}</td>
+                  <td>{{ fmtPrice(a.basePrice) }}</td>
+                  <td>{{ fmtPrice(a.winnerBid?.amount || a.basePrice) }}</td>
                 </tr>
               </tbody>
             </table>
@@ -102,13 +113,19 @@ async function submitRelist() {
             <h2>Zakończone</h2>
             <table>
               <thead>
-                <tr><th>Tytuł</th><th>Zwycięzca</th><th>Kwota</th></tr>
+                <tr>
+                  <th>Tytuł</th>
+                  <th>Zwycięzca</th>
+                  <th>Kwota</th>
+                  <th>Zakończenie</th>
+                </tr>
               </thead>
               <tbody>
                 <tr v-for="a in overview.ended" :key="a.id">
                   <td>{{ a.title }}</td>
                   <td>{{ a.winnerBid?.user.name || '—' }}</td>
                   <td>{{ fmtPrice(a.winnerBid?.amount || 0) }}</td>
+                  <td>{{ fmtDate(a.endsAt) }}</td>
                 </tr>
               </tbody>
             </table>

--- a/frontend/src/pages/AdminHome.vue
+++ b/frontend/src/pages/AdminHome.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <section class="admin-dashboard">
+    <h1>Panel administracyjny</h1>
+    <div class="admin-layout">
+      <aside class="admin-nav">
+        <ul>
+          <li><router-link to="/admin/create">Dodaj Aukcję</router-link></li>
+          <li><router-link to="/admin/auctions">Aukcje</router-link></li>
+          <li><router-link to="/admin/settings">Ustawienia</router-link></li>
+        </ul>
+      </aside>
+      <main class="admin-content">
+        <p>Wybierz sekcję z menu po lewej.</p>
+      </main>
+    </div>
+  </section>
+</template>

--- a/frontend/src/pages/AdminSettings.vue
+++ b/frontend/src/pages/AdminSettings.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const maxActiveAuctions = ref('');
+const maxWonAuctions = ref('');
+</script>
+
+<template>
+  <section class="admin-dashboard">
+    <h1>Panel administracyjny</h1>
+    <div class="admin-layout">
+      <aside class="admin-nav">
+        <ul>
+          <li><router-link to="/admin/create">Dodaj Aukcję</router-link></li>
+          <li><router-link to="/admin/auctions">Aukcje</router-link></li>
+          <li><router-link to="/admin/settings">Ustawienia</router-link></li>
+        </ul>
+      </aside>
+      <main class="admin-content">
+        <h2>Ustawienia</h2>
+        <form class="form">
+          <label>Maks. aukcji na użytkownika:
+            <input v-model="maxActiveAuctions" type="number" />
+          </label>
+          <label>Maks. wygranych aukcji:
+            <input v-model="maxWonAuctions" type="number" />
+          </label>
+        </form>
+      </main>
+    </div>
+  </section>
+</template>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,27 +1,73 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+const fullText = `Dołącz do naszych licytacji firmowego sprzętu komputerowego – głównie laptopów używanych w różnym stanie technicznym. Każdy przedmiot ma indywidualny opis, abyś mógł dokładnie poznać jego specyfikację i stan przed licytacją. Licytuj w czasie rzeczywistym i zdobądź sprzęt w korzystnej cenie. Sprawdź aktualne aukcje i złóż swoją ofertę już teraz!`;
+const typed = ref('');
+
+onMounted(() => {
+  let i = 0;
+  const timer = setInterval(() => {
+    typed.value = fullText.slice(0, i++);
+    if (i > fullText.length) clearInterval(timer);
+  }, 30);
+});
 </script>
 
 <template>
-  <section class="home-section top">
-    <h1>Witamy w Altkom Software</h1>
-    <p>Platforma aukcyjna z nowoczesnym, szarym motywem.</p>
-  </section>
-  <section class="home-section middle">
-    <h2>Dlaczego my?</h2>
-    <p>Bezpieczne licytacje, przejrzysty panel administracyjny i szybkie płatności.</p>
-  </section>
-  <section class="home-section bottom">
-    <h2>Dołącz do nas</h2>
-    <p>Załóż konto i wystaw swoją pierwszą aukcję już dziś.</p>
+  <section class="home-hero">
+    <h1>
+      Witamy na Aukcji Sprzętu
+      <span class="brand inline-brand">
+        <span class="logo-alt">alt</span><span class="logo-kom">kom</span>
+        <span class="logo-om">software</span>
+      </span>
+    </h1>
+    <p class="hero-subtitle typewriter">{{ typed }}</p>
+    <router-link to="/auctions" class="cta-button">Zobacz Aktualne Aukcje</router-link>
   </section>
 </template>
 
 <style scoped>
-.home-section {
-  padding: 40px 20px;
+.home-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  padding: 80px 20px;
 }
-.top { background: #f0f0f0; }
-.middle { background: #e0e0e0; }
-.bottom { background: #d0d0d0; }
+
+.inline-brand {
+  margin-left: 8px;
+}
+
+.typewriter {
+  border-right: 0.15em solid #ff4f64;
+  white-space: pre-line;
+  animation: caret 1s steps(1, end) infinite;
+}
+
+@keyframes caret {
+  from { border-right-color: #ff4f64; }
+  to { border-right-color: transparent; }
+}
+
+.hero-subtitle {
+  max-width: 800px;
+  margin-top: 20px;
+}
+
+.cta-button {
+  margin-top: 30px;
+  background: #0059b3;
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 25px;
+  transition: background-color 0.3s;
+  display: inline-block;
+}
+
+.cta-button:hover {
+  background: #0066cc;
+}
 </style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,9 +4,11 @@ import Auctions from "@/pages/Auctions.vue";
 import Info from "@/pages/Info.vue";
 import Contact from "@/pages/Contact.vue";
 import Login from "@/pages/Login.vue";
-import CreateAuction from "@/pages/CreateAuction.vue";
 import AuctionDetail from "@/pages/AuctionDetail.vue";
-import AdminDashboard from "@/pages/AdminDashboard.vue";
+import AdminHome from "@/pages/AdminHome.vue";
+import AdminAuctions from "@/pages/AdminAuctions.vue";
+import CreateAuction from "@/pages/CreateAuction.vue";
+import AdminSettings from "@/pages/AdminSettings.vue";
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -16,8 +18,10 @@ export const router = createRouter({
     { path: "/info", component: Info },
     { path: "/contact", component: Contact },
     { path: "/login", component: Login },
-    { path: "/create", component: CreateAuction },
-    { path: "/admin", component: AdminDashboard },
+    { path: "/admin/auctions", component: AdminAuctions },
+    { path: "/admin/create", component: CreateAuction },
+    { path: "/admin/settings", component: AdminSettings },
+    { path: "/admin", component: AdminHome },
     { path: "/auction/:id", component: AuctionDetail },
   ],
 });

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -55,9 +55,6 @@ button:focus-visible {
 .brand {
   display: inline-flex;
   align-items: center;
-  background: #1c1c1c;
-  padding: 4px 8px;
-  border-radius: 4px;
   font-weight: 700;
   font-size: 1.1rem;
   color: #ff4f64;
@@ -68,17 +65,15 @@ button:focus-visible {
 .logo-om {
   color: #ff4f64;
 }
-.logo-box {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: #ff4f64;
-  margin: 0 2px;
-  padding: 0 4px;
+.logo-om {
+  margin-left: 4px;
 }
-.logo-k {
-  color: #1c1c1c;
-  font-weight: 700;
+.logo-kom {
+  background: #ff4f64;
+  color: #fff;
+  margin-left: 2px;
+  padding: 0 4px;
+  border-radius: 4px;
 }
 .nav-links {
   justify-self: center;
@@ -124,6 +119,16 @@ button:focus-visible {
 .btn.small {
   font-size: 0.8rem;
   padding: 0.3em 0.6em;
+}
+
+.logout-btn {
+  background: #cc0000;
+  border-color: #cc0000;
+}
+
+.logout-btn:hover {
+  background: #ff3333;
+  border-color: #ff3333;
 }
 
 .container {
@@ -267,6 +272,11 @@ button:focus-visible {
 
 .admin-layout {
   display: flex;
+  width: 100%;
+}
+
+.admin-dashboard {
+  margin: 0;
 }
 
 .admin-nav {
@@ -274,6 +284,7 @@ button:focus-visible {
   background: #f0f0f0;
   padding: 20px;
   border-right: 1px solid #d6d6d6;
+  margin-right: 40px;
 }
 
 .admin-nav ul {
@@ -284,20 +295,19 @@ button:focus-visible {
 
 .admin-nav li {
   margin-bottom: 10px;
+}
+
+.admin-nav a {
+  display: block;
   padding: 8px;
   border-radius: 4px;
-  cursor: pointer;
-}
-
-.admin-nav li.active {
-  background: #0059b3;
-  color: #fff;
-}
-
-.admin-nav li a {
   color: inherit;
   text-decoration: none;
-  display: block;
+}
+
+.admin-nav a.router-link-active {
+  background: #0059b3;
+  color: #fff;
 }
 
 .auction-overview {


### PR DESCRIPTION
## Summary
- Refine branding with white "kom" highlight and remove dark background
- Apply typewriter effect to home subtitle and keep header static
- Move auction overview to `/admin/auctions` with enhanced tables and sidebar spacing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897e2bf3c8883258647ee9b1ad85cf3