### PR TITLE
Add condition field and refresh auction UI

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,15 @@ enum AuctionStatus {
   CANCELED
 }
 
+// Stan sprzętu wystawionego na aukcję
+enum ItemCondition {
+  NOWY
+  BARDZO_DOBRY
+  DOBRY
+  USZKODZONY
+  DO_NAPRAWY
+}
+
 enum LogAction {
   USER_REGISTER
   USER_LOGIN
@@ -47,6 +56,10 @@ model Auction {
   basePrice    Int
   minIncrement Int
   reservePrice Int?
+  condition    ItemCondition  @default(DOBRY)
+  personalPickup  Boolean     @default(false)
+  courierShipping Boolean     @default(false)
+  invoice      Boolean        @default(false)
   status       AuctionStatus  @default(DRAFT)
   startsAt     DateTime
   endsAt       DateTime

--- a/backend/src/routes/auctions.routes.ts
+++ b/backend/src/routes/auctions.routes.ts
@@ -20,7 +20,7 @@ function toGrosze(v: string | number | undefined) {
 auctionsRouter.get("/", async (_req, res) => {
   const auctions = await prisma.auction.findMany({
     where: { status: "ACTIVE" },
-    include: { images: true },
+    include: { images: true, bids: true },
     orderBy: { endsAt: "asc" },
   });
   res.json(auctions);
@@ -81,6 +81,10 @@ auctionsRouter.post(
       basePricePLN,
       minIncrementPLN,
       reservePricePLN,
+      condition,
+      personalPickup,
+      courierShipping,
+      invoice,
       startsAt,
       endsAt,
     } = req.body ?? {};
@@ -91,7 +95,8 @@ auctionsRouter.post(
       !basePricePLN ||
       !minIncrementPLN ||
       !startsAt ||
-      !endsAt
+      !endsAt ||
+      !condition
     ) {
       return res.status(400).json({ message: "Missing fields" });
     }
@@ -109,6 +114,10 @@ auctionsRouter.post(
         basePrice: toGrosze(basePricePLN),
         minIncrement: toGrosze(minIncrementPLN),
         reservePrice: reservePricePLN ? toGrosze(reservePricePLN) : null,
+        condition,
+        personalPickup: personalPickup === "true",
+        courierShipping: courierShipping === "true",
+        invoice: invoice === "true",
         status: "ACTIVE",
         startsAt: new Date(startsAt),
         endsAt: new Date(endsAt),
@@ -145,6 +154,10 @@ auctionsRouter.post(
         basePrice: toGrosze(basePricePLN),
         minIncrement: toGrosze(minIncrementPLN),
         reservePrice: old.reservePrice,
+        condition: old.condition,
+        personalPickup: old.personalPickup,
+        courierShipping: old.courierShipping,
+        invoice: old.invoice,
         status: "ACTIVE",
         startsAt: new Date(startsAt),
         endsAt: new Date(endsAt),

--- a/frontend/src/pages/AuctionDetail.vue
+++ b/frontend/src/pages/AuctionDetail.vue
@@ -12,6 +12,14 @@ const auction = ref<any>(null);
 const topAmount = ref(0);         // grosze
 const myBidPLN = ref<string>("");
 const msg = ref<string | null>(null);
+const currentImg = ref(0);
+const conditionLabel: Record<string, string> = {
+  NOWY: 'Nowy',
+  BARDZO_DOBRY: 'Bardzo dobry',
+  DOBRY: 'Dobry',
+  USZKODZONY: 'Uszkodzony',
+  DO_NAPRAWY: 'Do naprawy',
+};
 
 let timer: number | undefined;
 
@@ -23,6 +31,7 @@ async function loadFull() {
   const { data } = await api.get(`/auctions/${id}`);
   auction.value = data;
   topAmount.value = Math.max(data.basePrice, data.bids?.[0]?.amount || 0);
+  currentImg.value = 0;
 }
 
 async function pollTop() {
@@ -67,42 +76,143 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div v-if="auction">
-    <h1 style="margin-bottom:8px">{{ auction.title }}</h1>
-
-    <div style="display:flex; gap:16px; align-items:flex-start">
-      <div style="display:flex; flex-direction:column; gap:8px">
+  <div v-if="auction" class="auction-detail">
+    <div class="gallery">
+      <img
+        v-if="auction.images?.[currentImg]"
+        :src="`${backend}${auction.images[currentImg].url}`"
+        alt=""
+        class="main-image"
+      />
+      <div v-if="auction.images?.length > 1" class="thumbs">
         <img
-          v-if="auction.images?.[0]"
-          :src="`${backend}${auction.images[0].url}`"
-          style="width:360px;height:240px;object-fit:cover;border-radius:8px"
+          v-for="(img, i) in auction.images"
+          :key="img.url"
+          :src="`${backend}${img.url}`"
+          :class="['thumb', { active: i === currentImg }]"
+          @click="currentImg = i"
         />
-        <div v-if="auction.images?.length > 1" style="display:flex; gap:4px; flex-wrap:wrap">
-          <img
-            v-for="img in auction.images.slice(1)"
-            :key="img.url"
-            :src="`${backend}${img.url}`"
-            style="width:80px;height:60px;object-fit:cover;border-radius:4px"
-          />
-        </div>
-      </div>
-      <div style="flex:1">
-        <p style="margin:8px 0 16px">{{ auction.description }}</p>
-        <div>Kończy się: {{ new Date(auction.endsAt).toLocaleString() }}</div>
-
-        <div style="font-size:20px;margin:12px 0">
-          Aktualna oferta: <b>{{ toPLN(topAmount) }} PLN</b>
-          <span v-if="auction.status === 'ENDED'" style="color:#f66"> (aukcja zakończona)</span>
-        </div>
-
-        <div v-if="auction.status !== 'ENDED'" style="display:flex; gap:8px; align-items:center">
-          <input v-model="myBidPLN" type="number" step="0.01" placeholder="Twoja oferta (PLN)" />
-          <button @click="placeBid">Licytuj</button>
-        </div>
-        <p v-if="msg" style="color:red;margin-top:8px">{{ msg }}</p>
       </div>
     </div>
+    <div class="bid-panel">
+      <h1 class="auction-title">{{ auction.title }}</h1>
+      <span class="detail-condition">{{ conditionLabel[auction.condition] || auction.condition }}</span>
+      <p class="auction-desc">{{ auction.description }}</p>
+      <div class="price-box">
+        <span class="label">Aktualna oferta</span>
+        <div class="price">{{ toPLN(topAmount) }} PLN</div>
+      </div>
+      <div class="timer">Kończy się: {{ new Date(auction.endsAt).toLocaleString() }}</div>
+      <div v-if="auction.status !== 'ENDED'" class="bid-form">
+        <input v-model="myBidPLN" type="number" step="0.01" placeholder="Twoja oferta (PLN)" />
+        <button @click="placeBid">Licytuj</button>
+        <p class="bid-hint">Min. przebicie: {{ toPLN(auction.minIncrement) }} PLN</p>
+      </div>
+      <ul class="options">
+        <li v-if="auction.personalPickup">Odbiór osobisty</li>
+        <li v-if="auction.courierShipping">Wysyłka kurierem</li>
+        <li>Faktura: {{ auction.invoice ? 'możliwa' : 'brak' }}</li>
+      </ul>
+      <p v-if="msg" class="error">{{ msg }}</p>
+    </div>
   </div>
-
   <p v-else>Ładowanie…</p>
 </template>
+
+<style scoped>
+.auction-detail {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  gap: 24px;
+}
+.gallery {
+  flex: 1;
+}
+.main-image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 12px;
+}
+.thumbs {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.thumb {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 8px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: transform 0.2s, opacity 0.2s;
+}
+.thumb:hover {
+  transform: scale(1.02);
+  opacity: 1;
+}
+.thumb.active {
+  border: 2px solid #ff4f64;
+  opacity: 1;
+}
+.bid-panel {
+  width: 100%;
+  max-width: 420px;
+  position: sticky;
+  top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.auction-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+.detail-condition {
+  align-self: flex-start;
+  background: #ff4f64;
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.price-box .label {
+  font-size: 14px;
+  color: #6b7280;
+}
+.price-box .price {
+  font-size: 32px;
+  font-weight: 700;
+}
+.timer {
+  font-family: monospace;
+  font-weight: 600;
+}
+.bid-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.bid-form input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.options {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #6b7280;
+}
+.error {
+  color: red;
+}
+</style>

--- a/frontend/src/pages/Auctions.vue
+++ b/frontend/src/pages/Auctions.vue
@@ -12,6 +12,8 @@ type Auction = {
   images: { url: string; position: number }[];
   basePrice: number;
   minIncrement: number;
+  bids: { amount: number }[];
+  condition: string;
 };
 
 const auctions = ref<Auction[]>([]);
@@ -32,6 +34,23 @@ onMounted(async () => {
 function fmtDate(s: string) {
   return new Date(s).toLocaleString();
 }
+
+function fmtPrice(g: number) {
+  return (g / 100).toFixed(2);
+}
+
+const conditionLabel: Record<string, string> = {
+  NOWY: 'Nowy',
+  BARDZO_DOBRY: 'Bardzo dobry',
+  DOBRY: 'Dobry',
+  USZKODZONY: 'Uszkodzony',
+  DO_NAPRAWY: 'Do naprawy',
+};
+
+function currentPrice(a: Auction) {
+  const top = a.bids.length ? Math.max(...a.bids.map((b) => b.amount)) : 0;
+  return fmtPrice(Math.max(a.basePrice, top));
+}
 </script>
 
 <template>
@@ -51,15 +70,21 @@ function fmtDate(s: string) {
       class="auction-link"
     >
       <article class="auction-card">
-        <img
-          v-if="a.images?.[0]"
-          :src="`${backend}${a.images[0].url}`"
-          alt=""
-          class="auction-image"
-        />
-        <h3>{{ a.title }}</h3>
-        <p>{{ a.description }}</p>
-        <small>Kończy się: {{ fmtDate(a.endsAt) }}</small>
+        <div class="image-wrapper">
+          <img
+            v-if="a.images?.[0]"
+            :src="`${backend}${a.images[0].url}`"
+            alt=""
+            class="auction-image"
+          />
+          <span class="condition-badge">{{ conditionLabel[a.condition] || a.condition }}</span>
+        </div>
+        <div class="auction-info">
+          <h3 class="auction-title">{{ a.title }}</h3>
+          <div class="auction-price">{{ currentPrice(a) }} PLN</div>
+          <div class="auction-offers">{{ a.bids.length }} ofert</div>
+        </div>
+        <div class="auction-end">⏰ {{ fmtDate(a.endsAt) }}</div>
       </article>
     </router-link>
   </div>

--- a/frontend/src/pages/CreateAuction.vue
+++ b/frontend/src/pages/CreateAuction.vue
@@ -12,6 +12,10 @@ const extraImages = ref<File[]>([]);
 const mainPreview = ref<string>('');
 const extraPreviews = ref<string[]>([]);
 const ok = ref<string|null>(null); const error = ref<string|null>(null); const loading = ref(false);
+const condition = ref('DOBRY');
+const personalPickup = ref(false);
+const courierShipping = ref(false);
+const invoice = ref(false);
 
 function toISO(dt: string) { return dt ? new Date(dt).toISOString() : ""; }
 
@@ -24,6 +28,10 @@ async function submit() {
     fd.append("basePricePLN", basePricePLN.value);
     fd.append("minIncrementPLN", minIncrementPLN.value);
     if (reservePricePLN.value) fd.append("reservePricePLN", reservePricePLN.value);
+    fd.append("condition", condition.value);
+    fd.append("personalPickup", String(personalPickup.value));
+    fd.append("courierShipping", String(courierShipping.value));
+    fd.append("invoice", String(invoice.value));
     fd.append("startsAt", toISO(startsAt.value));
     fd.append("endsAt", toISO(endsAt.value));
     if (mainImage.value) fd.append("images", mainImage.value);
@@ -77,6 +85,18 @@ function onExtras(e: Event) {
           <label>Data Rozpoczęcia: <input v-model="startsAt" type="datetime-local" required /></label>
           <label>Data Zakończenia: <input v-model="endsAt" type="datetime-local" required /></label>
         </div>
+        <label>Stan sprzętu:
+          <select v-model="condition">
+            <option value="NOWY">Nowy</option>
+            <option value="BARDZO_DOBRY">Bardzo dobry</option>
+            <option value="DOBRY">Dobry</option>
+            <option value="USZKODZONY">Uszkodzony</option>
+            <option value="DO_NAPRAWY">Do naprawy</option>
+          </select>
+        </label>
+        <label><input type="checkbox" v-model="personalPickup" /> Odbiór osobisty</label>
+        <label><input type="checkbox" v-model="courierShipping" /> Wysyłka kurierem</label>
+        <label><input type="checkbox" v-model="invoice" /> Faktura dostępna</label>
         <label>Główne zdjęcie: <input type="file" @change="onMain" /></label>
         <div class="preview-images" v-if="mainPreview">
           <img :src="mainPreview" />

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -3,7 +3,7 @@
 
 <template>
   <section class="home-hero">
-    <h1 class="typewriter">
+    <h1 class="welcome">
       Witamy na Aukcji Sprzętu
       <span class="brand inline-brand">
         <span class="logo-alt">alt</span>
@@ -29,19 +29,11 @@
 }
 
 .inline-brand {
-  margin-left: 8px;
+  margin-left: 4px;
 }
 
-.typewriter {
-  overflow: hidden;
-  white-space: nowrap;
-  border-right: 0.15em solid #ff4f64;
-  animation: typing 6s steps(60, end);
-}
-
-@keyframes typing {
-  from { width: 0 }
-  to { width: 100% }
+.welcome {
+  white-space: normal;
 }
 
 .hero-subtitle {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -73,7 +73,7 @@ button:focus-visible {
   align-items: center;
   justify-content: center;
   background: #ff4f64;
-  margin: 0 2px;
+  margin: 0 1px;
   padding: 0 4px;
 }
 .logo-k {
@@ -152,27 +152,63 @@ button:focus-visible {
   color: inherit;
 }
 .auction-card {
-  border: 1px solid #eee;
-  border-radius: 8px;
-  padding: 12px;
-  transition: 0.15s box-shadow;
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
 }
 .auction-card:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transform: scale(1.03);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+}
+.image-wrapper {
+  position: relative;
 }
 .auction-image {
   width: 100%;
-  height: 160px;
+  height: 180px;
   object-fit: cover;
-  border-radius: 6px;
+  display: block;
 }
-.auction-card h3 {
-  margin: 8px 0 4px;
+.condition-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: #ff4f64;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
 }
-.auction-card p {
-  color: #555;
+.auction-info {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+.auction-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+.auction-price {
+  font-size: 18px;
+  font-weight: 700;
+}
+.auction-offers {
   font-size: 14px;
-  min-height: 40px;
+  color: #555;
+}
+.auction-end {
+  background: #e53935;
+  color: #fff;
+  padding: 4px 8px;
+  text-align: center;
+  font-size: 14px;
 }
 
 .form {
@@ -284,6 +320,8 @@ button:focus-visible {
   background: #f0f0f0;
   padding: 20px;
   border-right: 1px solid #d6d6d6;
+  min-height: 100vh;
+  box-sizing: border-box;
 }
 
 .admin-nav ul {


### PR DESCRIPTION
## Summary
- add item condition and delivery options to auctions
- redesign auction list and details layout
- tidy branding spacing, remove typewriter cursor, stabilize admin nav

## Testing
- `npx prisma generate`
- `npx prisma db push` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test` *(backend)*
- `npm run build` *(backend)*
- `npm test` *(frontend)*
- `npm run build` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_6897edfc4a808325a0283468e999ce29