### PR TITLE
Fix admin login and show latest auctions on home

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "scripts": {
     "prisma:generate": "prisma generate",
-    "dev": "npm run prisma:generate && ts-node-dev --respawn src/server.ts",
-    "build": "npm run prisma:generate && tsc -p .",
+    "prisma:push": "prisma db push",
+    "dev": "npm run prisma:push && ts-node-dev --respawn src/server.ts",
+    "build": "npm run prisma:push && tsc -p .",
     "start": "node dist/server.js",
-    "seed:admin": "ts-node ./scripts/seed-admin.ts",
-    "make:admin": "ts-node ./scripts/make-admin.ts"
+    "seed:admin": "npm run prisma:push && ts-node ./scripts/seed-admin.ts",
+    "make:admin": "npm run prisma:push && ts-node ./scripts/make-admin.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/make-admin.ts
+++ b/backend/scripts/make-admin.ts
@@ -12,10 +12,10 @@ const prisma = new PrismaClient();
 
   await prisma.user.upsert({
     where: { email },
-    update: { role: "ADMIN" },
+    update: { role: "ADMIN", passwordHash },
     create: { email, name, passwordHash, role: "ADMIN" }
   });
 
-  console.log("Admin ensured:", email);
+  console.log("Admin ensured:", email, "password:", password);
   await prisma.$disconnect();
 })();

--- a/backend/src/routes/auctions.routes.ts
+++ b/backend/src/routes/auctions.routes.ts
@@ -17,11 +17,18 @@ function toGrosze(v: string | number | undefined) {
 }
 
 // ----------------------------- LISTA -----------------------------
-auctionsRouter.get("/", async (_req, res) => {
+auctionsRouter.get("/", async (req, res) => {
+  const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : undefined;
+  const orderBy =
+    req.query.sort === "latest"
+      ? { createdAt: "desc" as const }
+      : { endsAt: "asc" as const };
+
   const auctions = await prisma.auction.findMany({
     where: { status: "ACTIVE" },
     include: { images: true, bids: true },
-    orderBy: { endsAt: "asc" },
+    orderBy,
+    ...(limit ? { take: limit } : {}),
   });
   res.json(auctions);
 });

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -29,7 +29,7 @@ authRouter.post("/register", async (req, res) => {
 authRouter.post("/login", async (req, res) => {
   const { email, password } = req.body ?? {};
   const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) {
+  if (!user || !user.passwordHash) {
     return res.status(401).json({ message: "Invalid credentials" });
   }
 

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,4 +1,38 @@
 <script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { api } from "@/api";
+
+const backend = import.meta.env.VITE_BACKEND_URL as string;
+
+type Auction = {
+  id: string;
+  title: string;
+  basePrice: number;
+  bids: { amount: number }[];
+  images: { url: string; position: number }[];
+};
+
+const latest = ref<Auction[]>([]);
+
+onMounted(async () => {
+  try {
+    const { data } = await api.get("/auctions", {
+      params: { limit: 3, sort: "latest" },
+    });
+    latest.value = data;
+  } catch (e) {
+    // ignore
+  }
+});
+
+function fmtPrice(g: number) {
+  return (g / 100).toFixed(2);
+}
+
+function currentPrice(a: Auction) {
+  const top = a.bids.length ? Math.max(...a.bids.map((b) => b.amount)) : 0;
+  return fmtPrice(Math.max(a.basePrice, top));
+}
 </script>
 
 <template>
@@ -14,6 +48,24 @@
     <p class="hero-subtitle">
       Dołącz do naszych licytacji firmowego sprzętu komputerowego – głównie laptopów używanych w różnym stanie technicznym. Każdy przedmiot ma indywidualny opis, abyś mógł dokładnie poznać jego specyfikację i stan przed licytacją. Licytuj w czasie rzeczywistym i zdobądź sprzęt w korzystnej cenie. Sprawdź aktualne aukcje i złóż swoją ofertę już teraz!
     </p>
+
+    <div v-if="latest.length" class="latest-auctions">
+      <article v-for="a in latest" :key="a.id" class="latest-card">
+        <img
+          v-if="a.images?.[0]"
+          :src="`${backend}${a.images[0].url}`"
+          alt=""
+          class="latest-image"
+        />
+        <div class="latest-info">
+          <router-link :to="`/auction/${a.id}`" class="latest-title">
+            {{ a.title }}
+          </router-link>
+          <div class="latest-price">{{ currentPrice(a) }} PLN</div>
+        </div>
+      </article>
+    </div>
+
     <router-link to="/auctions" class="cta-button">Zobacz Aktualne Aukcje</router-link>
   </section>
 </template>
@@ -53,5 +105,33 @@
 
 .cta-button:hover {
   background: #0066cc;
+}
+
+.latest-auctions {
+  display: flex;
+  gap: 16px;
+  margin-top: 30px;
+}
+
+.latest-card {
+  width: 200px;
+  text-align: left;
+}
+
+.latest-image {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.latest-title {
+  font-weight: bold;
+  display: block;
+  margin-top: 8px;
+}
+
+.latest-price {
+  color: #555;
 }
 </style>


### PR DESCRIPTION
## Summary
- Ensure admin creation script updates password and role
- Handle missing password hashes during login
- Add query params to auctions list for latest previews
- Display three latest active auctions on home page
- Sync database schema before running backend scripts

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script)*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6898ca40c1f88325a1f106714187f65b