### PR TITLE
Implement auction schedule settings and fix admin login

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -100,3 +100,10 @@ model AuditLog {
   meta      Json
   createdAt DateTime  @default(now())
 }
+
+model Settings {
+  id                Int       @id @default(1)
+  maxActiveAuctions Int       @default(0)
+  maxWonAuctions    Int       @default(0)
+  nextAuctionIso    DateTime?
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import { prisma } from "./prisma";
 import { authRouter } from "./routes/auth.routes";
 import { auctionsRouter } from "./routes/auctions.routes";
+import { settingsRouter } from "./routes/settings.routes";
 
 const app = express();
 
@@ -35,5 +36,6 @@ app.get("/api/db-ok", async (_req, res) => {
 // Podpięcie routerów
 app.use("/api/auth", authRouter);
 app.use("/api/auctions", auctionsRouter);
+app.use("/api/settings", settingsRouter);
 
 export default app;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,13 +1,15 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 
+const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
+
 export type JwtUser = { id: string; role: "USER" | "ADMIN"; name: string };
 
 export function requireAuth(req: Request, res: Response, next: NextFunction) {
   const token = req.cookies?.token;
   if (!token) return res.status(401).json({ message: "Unauthorized" });
   try {
-    const user = jwt.verify(token, process.env.JWT_SECRET!) as JwtUser;
+    const user = jwt.verify(token, JWT_SECRET) as JwtUser;
     (req as any).user = user;
     next();
   } catch {

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -6,6 +6,7 @@ import ldap from "ldapjs";
 import { promisify } from "util";
 
 export const authRouter = Router();
+const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
 
 authRouter.post("/register", async (req, res) => {
   const { email, password, name } = req.body ?? {};
@@ -40,7 +41,7 @@ authRouter.post("/login", async (req, res) => {
 
   const token = jwt.sign(
     { id: user.id, role: user.role, name: user.name },
-    process.env.JWT_SECRET!,
+    JWT_SECRET,
     { expiresIn: "7d" }
   );
 
@@ -56,7 +57,7 @@ authRouter.post("/sso", async (_req, res) => {
   }
   const token = jwt.sign(
     { id: user.id, role: user.role, name: user.name },
-    process.env.JWT_SECRET!,
+    JWT_SECRET,
     { expiresIn: "7d" }
   );
   res.cookie("token", token, { httpOnly: true, sameSite: "lax" });
@@ -93,7 +94,7 @@ authRouter.post("/ldap", async (req, res) => {
 
   const token = jwt.sign(
     { id: user.id, role: user.role, name: user.name },
-    process.env.JWT_SECRET!,
+    JWT_SECRET,
     { expiresIn: "7d" }
   );
   res.cookie("token", token, { httpOnly: true, sameSite: "lax" });

--- a/backend/src/routes/settings.routes.ts
+++ b/backend/src/routes/settings.routes.ts
@@ -1,0 +1,57 @@
+import { Router } from "express";
+import { prisma } from "../prisma";
+import { requireAuth, requireAdmin } from "../middleware/auth";
+
+export const settingsRouter = Router();
+
+async function loadSettings() {
+  let s = await prisma.settings.findUnique({ where: { id: 1 } });
+  if (!s) {
+    s = await prisma.settings.create({ data: { id: 1 } });
+  }
+  return s;
+}
+
+settingsRouter.get("/", async (_req, res) => {
+  const s = await loadSettings();
+  res.json({
+    maxActiveAuctions: s.maxActiveAuctions,
+    maxWonAuctions: s.maxWonAuctions,
+    nextAuctionIso: s.nextAuctionIso,
+  });
+});
+
+const saveHandler = async (req: any, res: any) => {
+  const body = req.body ?? {};
+  const data: any = {};
+  if (body.maxActiveAuctions !== undefined)
+    data.maxActiveAuctions = Number(body.maxActiveAuctions);
+  if (body.maxWonAuctions !== undefined)
+    data.maxWonAuctions = Number(body.maxWonAuctions);
+  if (body.max_won_auctions !== undefined)
+    data.maxWonAuctions = Number(body.max_won_auctions);
+  const iso =
+    body.nextAuctionIso ||
+    body.nextAuctionAt ||
+    body.nextAuctionDate ||
+    body.nextAuction ||
+    null;
+  if (iso !== undefined) {
+    data.nextAuctionIso = iso ? new Date(iso) : null;
+  }
+  const s = await prisma.settings.upsert({
+    where: { id: 1 },
+    update: data,
+    create: { id: 1, ...data },
+  });
+  res.json({
+    maxActiveAuctions: s.maxActiveAuctions,
+    maxWonAuctions: s.maxWonAuctions,
+    nextAuctionIso: s.nextAuctionIso,
+  });
+};
+
+settingsRouter.patch("/", requireAuth, requireAdmin, saveHandler);
+settingsRouter.put("/", requireAuth, requireAdmin, saveHandler);
+settingsRouter.post("/", requireAuth, requireAdmin, saveHandler);
+

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,8 @@ import { Server } from "socket.io";
 import app from "./app";
 import { attachBidding } from "./services/bidding";
 import { startCloseExpiredWorker } from "./services/closeExpired";
+import { prisma } from "./prisma";
+import bcrypt from "bcrypt";
 
 const port = Number(process.env.PORT || 4000);
 const server = http.createServer(app);
@@ -15,6 +17,23 @@ const io = new Server(server, {
 
 attachBidding(io);
 
-server.listen(port, () => {
-  console.log(`API listening on :${port}`);
-});
+async function ensureAdmin() {
+  const email = process.env.ADMIN_EMAIL || "admin@local.test";
+  const password = process.env.ADMIN_PASSWORD || "Admin123!";
+  const name = "Admin";
+  const exists = await prisma.user.findUnique({ where: { email } });
+  if (!exists) {
+    const passwordHash = await bcrypt.hash(password, 12);
+    await prisma.user.create({
+      data: { email, name, passwordHash, role: "ADMIN" }
+    });
+    console.log(`Created default admin ${email}`);
+  }
+}
+
+(async () => {
+  await ensureAdmin().catch((e) => console.error("Admin seed failed", e));
+  server.listen(port, () => {
+    console.log(`API listening on :${port}`);
+  });
+})();


### PR DESCRIPTION
## Summary
- add settings model and API to configure next auction time
- default JWT secret and seed a local admin for login
- expose settings route via API

## Testing
- `DATABASE_URL="file:./prisma/dev.db" npx prisma db push --skip-generate`
- `DATABASE_URL="file:./prisma/dev.db" npx prisma generate`
- `npm test` (backend) *(fails: Missing script)*
- `npm test` (frontend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6898dafbab548325947cab148434ff4a