### PR TITLE
Improve auction visibility and admin overview

### DIFF
--- a/backend/src/routes/auctions.routes.ts
+++ b/backend/src/routes/auctions.routes.ts
@@ -51,6 +51,13 @@ auctionsRouter.get(
     const active = await prisma.auction.findMany({
       where: { status: "ACTIVE" },
       orderBy: { endsAt: "asc" },
+      include: {
+        bids: {
+          orderBy: { amount: "desc" },
+          take: 1,
+          include: { user: { select: { id: true, name: true } } },
+        },
+      },
     });
 
     const noBids = ended.filter((a) => a.bids.length === 0);

--- a/frontend/src/pages/Auctions.vue
+++ b/frontend/src/pages/Auctions.vue
@@ -47,6 +47,14 @@ const conditionLabel: Record<string, string> = {
   DO_NAPRAWY: 'Do naprawy',
 };
 
+const conditionColor: Record<string, string> = {
+  DO_NAPRAWY: '#FFA500',
+  USZKODZONY: '#FF0000',
+  DOBRY: '#FFFF00',
+  BARDZO_DOBRY: '#00FFFF',
+  NOWY: '#008000',
+};
+
 function currentPrice(a: Auction) {
   const top = a.bids.length ? Math.max(...a.bids.map((b) => b.amount)) : 0;
   return fmtPrice(Math.max(a.basePrice, top));
@@ -78,7 +86,9 @@ function currentPrice(a: Auction) {
             alt=""
             class="auction-image"
           />
-          <span class="condition-badge">{{ conditionLabel[a.condition] || a.condition }}</span>
+          <span class="condition-badge" :style="{ background: conditionColor[a.condition] }">
+            {{ conditionLabel[a.condition] || a.condition }}
+          </span>
         </div>
         <div class="auction-info">
           <h3 class="auction-title">{{ a.title }}</h3>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -143,8 +143,14 @@ button:focus-visible {
 
 .auction-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(5, 1fr);
   gap: 16px;
+}
+
+@media (max-width: 1000px) {
+  .auction-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
 }
 .auction-link {
   text-decoration: none;


### PR DESCRIPTION
## Summary
- Fix home countdown and only show latest auctions and navigation when active auctions are available
- Color-code auction condition badges, display five auctions per row, and show more detail timing info
- Extend admin dashboard with live price, winner and time remaining data for active auctions

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm test` (backend) *(fails: Missing script)*
- `npm run build` (frontend)
- `npm run build` (backend) *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6898e482f9ec8325b77c53bd9e2ad596