### PR TITLE
Fix auction activation logic and countdown display

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -1,11 +1,29 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue';
 import { useRouter } from 'vue-router';
+import { api } from '@/api';
 
 const router = useRouter();
 const user = computed(() => {
   const raw = localStorage.getItem('user');
   return raw ? JSON.parse(raw) : null;
+});
+
+const settings = ref<{ nextAuctionIso: string | null } | null>(null);
+const now = ref(Date.now());
+let timer: number | null = null;
+
+onMounted(async () => {
+  try { const { data } = await api.get('/settings'); settings.value = data; } catch {}
+  timer = window.setInterval(() => { now.value = Date.now(); }, 1000);
+});
+
+onBeforeUnmount(() => { if (timer) clearInterval(timer); });
+
+const auctionsActive = computed(() => {
+  const iso = settings.value?.nextAuctionIso;
+  if (!iso) return false;
+  return new Date(iso).getTime() <= now.value;
 });
 
 function logout() {
@@ -24,7 +42,7 @@ function logout() {
     </router-link>
     <nav class="nav-links">
       <router-link to="/">Strona Główna</router-link>
-      <router-link to="/auctions">Aukcje</router-link>
+      <router-link v-if="auctionsActive" to="/auctions">Aukcje</router-link>
       <router-link to="/info">Informacje</router-link>
       <router-link to="/contact">Kontakt</router-link>
     </nav>


### PR DESCRIPTION
## Summary
- show auction link and CTA only when auctions are active
- handle unscheduled, upcoming, and live auction states on home page
- fix flip-clock layout and ensure timer updates in real time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f526e1f08325ab17c01d9060d699