### PR TITLE
Add favorites, My Auctions view, and admin tools

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   createdAt    DateTime  @default(now())
   bids         Bid[]
   auctions     Auction[] @relation("SellerAuctions")
+  favorites    Favorite[]
 }
 
 model Auction {
@@ -71,6 +72,7 @@ model Auction {
   images       AuctionImage[]
   winnerBidId  String?        @unique // <--- tu dodane
   winnerBid    Bid?           @relation("Winner", fields: [winnerBidId], references: [id])
+  favorites    Favorite[]
 }
 
 model AuctionImage {
@@ -90,6 +92,16 @@ model Bid {
   auction   Auction  @relation(fields: [auctionId], references: [id])
   auctionId String
   winnerOf  Auction? @relation("Winner") // <--- to dodajemy
+}
+
+model Favorite {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  auction   Auction  @relation(fields: [auctionId], references: [id])
+  auctionId String
+
+  @@unique([userId, auctionId])
 }
 
 model AuditLog {

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -8,6 +8,8 @@ const user = computed(() => {
   const raw = localStorage.getItem('user');
   return raw ? JSON.parse(raw) : null;
 });
+const isAdmin = computed(() => user.value?.role === 'ADMIN');
+const menuOpen = ref(false);
 
 const settings = ref<{ nextAuctionIso: string | null } | null>(null);
 const now = ref(Date.now());
@@ -47,10 +49,25 @@ function logout() {
       <router-link to="/contact">Kontakt</router-link>
     </nav>
     <div class="user-links">
-      <router-link to="/admin" class="admin-link">Panel admina</router-link>
+      <div v-if="user">
+        <div v-if="isAdmin" class="admin-dropdown">
+          <button class="admin-link" @click="menuOpen = !menuOpen">Menu ▾</button>
+          <div v-if="menuOpen" class="dropdown-menu">
+            <router-link to="/admin" @click="menuOpen=false">Panel Admina</router-link>
+            <router-link to="/my-auctions" @click="menuOpen=false">Moje Aukcje</router-link>
+          </div>
+        </div>
+        <router-link v-else to="/my-auctions" class="admin-link">Moje Aukcje</router-link>
+      </div>
       <router-link v-if="!user" to="/login">Zaloguj</router-link>
       <span v-else class="welcome">Witaj, {{ user.name }}</span>
       <button v-if="user" class="btn small logout-btn" @click="logout">Wyloguj</button>
     </div>
   </header>
 </template>
+
+<style scoped>
+.admin-dropdown { position: relative; display:inline-block; }
+.dropdown-menu { position:absolute; right:0; background:#fff; border:1px solid #c9d3dd; display:flex; flex-direction:column; }
+.dropdown-menu a { padding:6px 12px; white-space:nowrap; }
+</style>

--- a/frontend/src/pages/AdminSettings.vue
+++ b/frontend/src/pages/AdminSettings.vue
@@ -9,6 +9,12 @@ const maxWonAuctions = ref<number | null>(null);
 const nextAuctionIso = ref<string | null>(null);
 
 const nextAuctionLocal = ref<string>(""); // YYYY-MM-DDTHH:mm
+function formatDisplay(iso: string) {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const year = String(d.getFullYear()).slice(-2);
+  return `${pad(d.getDate())}-${pad(d.getMonth() + 1)}-${year} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
 const saving = ref(false);
 const message = ref<{ type: "ok" | "err"; text: string } | null>(null);
 
@@ -195,7 +201,7 @@ onMounted(load);
           </div>
 
           <p v-if="message" :class="['msg', message.type]">{{ message.text }}</p>
-          <p class="hint">Aktualny termin (ISO): <strong>{{ nextAuctionIso || 'brak' }}</strong></p>
+          <p class="hint">Aktualny termin: <strong>{{ nextAuctionIso ? formatDisplay(nextAuctionIso) : 'brak' }}</strong></p>
         </div>
       </main>
     </div>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -8,6 +8,7 @@ import AuctionDetail from "@/pages/AuctionDetail.vue";
 import AdminDashboard from "@/pages/AdminDashboard.vue";
 import CreateAuction from "@/pages/CreateAuction.vue";
 import AdminSettings from "@/pages/AdminSettings.vue";
+import MyAuctions from "@/pages/MyAuctions.vue";
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -21,5 +22,6 @@ export const router = createRouter({
     { path: "/admin/settings", component: AdminSettings },
     { path: "/admin", component: AdminDashboard },
     { path: "/auction/:id", component: AuctionDetail },
+    { path: "/my-auctions", component: MyAuctions },
   ],
 });


### PR DESCRIPTION
## Summary
- Format settings page date display and show localized timestamp
- Allow users to favorite auctions, view them in new "My Auctions" page, and toggle via star icon
- Expand admin dashboard with edit/delete actions and expose favorites/management APIs

## Testing
- `npm run prisma:generate`
- `npm test` (backend) *(fails: Missing script)*
- `npm test` (frontend)
- `npm run prisma:push` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689a5941f3588325aa584a72d5cf9230