### PR TITLE
Prevent bidding when auction house closed and restrict admin pages

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -18,10 +18,19 @@ export const router = createRouter({
     { path: "/info", component: Info },
     { path: "/contact", component: Contact },
     { path: "/login", component: Login },
-    { path: "/admin/create", component: CreateAuction },
-    { path: "/admin/settings", component: AdminSettings },
-    { path: "/admin", component: AdminDashboard },
+    { path: "/admin/create", component: CreateAuction, meta: { requiresAdmin: true } },
+    { path: "/admin/settings", component: AdminSettings, meta: { requiresAdmin: true } },
+    { path: "/admin", component: AdminDashboard, meta: { requiresAdmin: true } },
     { path: "/auction/:id", component: AuctionDetail },
     { path: "/my-auctions", component: MyAuctions },
   ],
+});
+
+router.beforeEach((to, _from, next) => {
+  if ((to.meta as any).requiresAdmin) {
+    const raw = localStorage.getItem("user");
+    const user = raw ? JSON.parse(raw) : null;
+    if (!user || user.role !== "ADMIN") return next("/");
+  }
+  next();
 });


### PR DESCRIPTION
## Summary
- Block bidding via API and websocket when auction house is closed
- Restrict admin pages to administrators only
- Disable bidding UI when auction house is closed

## Testing
- `DATABASE_URL="file:./dev.db" npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa7ce08f48325a9e0931c6b3a8fb3